### PR TITLE
Support scylla AMI test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
-# Ansible Cassandra Cluster Stress 
+# Ansible Scylla and Cassandra Cluster Stress 
 
-A framework for running and automating Cassandra stress tests on Amazon EC2.
+A framework for running and automating Scylla/Cassandra stress tests on Amazon EC2.
 
 This repository contains Ansible playbooks and scripts for running
-Cassandra performance tests on EC2 with multiple Cassandra servers and
+Scylla/Cassandra performance tests on EC2 with multiple DB servers and
 multiple cassandra-stress loaders, as well as adding, stopping and
 starting nodes.
-
-Optional Graphite server, with [Tessera](http://urbanairship.com/blog/2014/06/30/introducing-tessera-a-graphite-frontend) front-end, collect and present
-relevant metrics.
 
 ### Prerequisites
 
@@ -77,15 +74,23 @@ Once security group exists, there is no need to repeat this step.
 You can use a different security group by adding ```-e
 "security_group=your_group_name"``` option to all ec2-setup-* scripts below.
 
-#### Launch Graphite server
-```
-./ec2-setup-graphite.sh
-```
-You can access the Graphite UI at port 8080, or the Tessera UI at
-port 80.
+#### Launch Scylla cluster
+Scylla servers launch from Scylla AMI, base on Fedora 22 (login fedora)
 
+```
+./ec2-setup-scylla.sh <options>
+```
+
+  **options**
+  * ```-e "cluster_nodes=2"``` - number of cluster nodes (default 2)
+  * ```-e "instance_type=c3.8xlarge"``` - type of EC2 instance
+
+Server are created with EC2 name *DB*, and tag "server=scylla"
 
 #### Launch Cassandra cluster
+Cassandra servers launch from AMI, , base on Ubuntu 14 (login ubuntu), or using package installation.
+See **cluster_ami** option below.
+
 ```
 ./ec2-setup-cassandra.sh <options>
 ```
@@ -96,7 +101,11 @@ port 80.
   * ```-e "num_tokens=6"``` - set number of vnode per server
   * ```-e "cluster_ami=false"``` - install Cassandra from RPM (default is using DataStax AMI)
 
+Server are created with EC2 name *DB*, and tag "server=cassandra"
+
 #### Launch Loaders
+Loaders are launch from Scylla AMI, base on Fedora 22 (login fedora), including a version of cassandra-stress which only use CQL, not thrift.
+
 ```
 ./ec2-setup-loadgen.sh <options>
 ```
@@ -123,7 +132,7 @@ port 80.
 ### Run Load
 
 ```
-./ec2-stress.sh <iterations> -e "load_name=late_night" <more options>
+./ec2-stress.sh <iterations> -e "load_name=late_night" -e "server=scylla" <more options>
 ```
 
 **Options**
@@ -133,6 +142,7 @@ All parameters are available at
 To override each of the parameter, use the ``-e "param=value"
 notation. Examples below:
 
+* ```-e "server=cassandra"``` - test cassandra servers (default is scylla)
 * ```-e "populate=2500000"``` - key population per loader (default is 1000000)
 * ```-e "command=write"``` [read, write,mixed,..] setting stress command
 * ```-e "stress_options='-schema \"replication(factor=2)\"'"```
@@ -171,11 +181,16 @@ update the **stopped** tag back to false.
 The next stress test will restart the Cassandra service.
 
 ### Terminate Servers
-(except the Graphite server)
 ```
 ./ec2-terminate.sh
 ```
 
+## Todo
+Scylla cluster does not yet support:
+* clean_data option, to clean data files before each stress
+* ec2-add-node-to-cluster, ec2-start-server.sh and ec2-stop-server.sh
+
+
 ## License
-The Cassandra Cluster Stress is distributed under the Apache License.
+The Scylla/Cassandra Cluster Stress is distributed under the Apache License.
 See LICENSE.TXT for more.

--- a/clean_data.yaml
+++ b/clean_data.yaml
@@ -1,13 +1,13 @@
 ---
 - name: Clean Data
   hosts: "Cassandra:&Origin:!Stopped"
-  user: "{{login_user}}"
+  user: "{{cassandra_login}}"
   tasks:
     - { include: roles/cassandra/tasks/clean.yaml, sudo: yes , when: clean_data == 'true' }
 
 - name: Restart Service - one by one
   hosts: "Cassandra:&Origin:!Stopped"
-  user: "{{login_user}}"
+  user: "{{cassandra_login}}"
   serial: 1
   tasks:
     - { include: roles/cassandra/tasks/start.yaml, when: clean_data == 'true' }

--- a/ec2-get-private-ips.py
+++ b/ec2-get-private-ips.py
@@ -5,12 +5,12 @@ import os
 import argparse
 
 
-def private_ips(ec2region,user,name):
+def private_ips(ec2region,user,name,server):
    conn = boto.ec2.connect_to_region(ec2region,
        aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID'),
        aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY'))
 
-   instances = conn.get_only_instances(filters={'tag:user':user, 'tag-value':name, 'tag:stopped':'false'})
+   instances = conn.get_only_instances(filters={'tag:user':user, 'tag-value':name, 'tag:stopped':'false', 'tag:server':server})
    for instance in instances:
        if (instance.state == "running"):
           print (instance.id),
@@ -23,5 +23,7 @@ if __name__ == "__main__":
     parser.add_argument('ec2region', action='store',nargs=1, help='ec2 region')
     parser.add_argument('ec2user', action='store',nargs=1, help='ec2 user tag')
     parser.add_argument('ec2instance', action='store',nargs=1, help='ec2 instance name')
+    parser.add_argument('ec2server', action='store',nargs=1, help='ec2 server type: scylla or cassandra')
+
     args = parser.parse_args()
-    private_ips(args.ec2region[0],args.ec2user[0],args.ec2instance[0])
+    private_ips(args.ec2region[0],args.ec2user[0],args.ec2instance[0],args.ec2server[0])

--- a/ec2-setup-loadgen.sh
+++ b/ec2-setup-loadgen.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ansible-playbook -i inventories/ec2/ setup-ec2-loadgen.yaml -e "collect_server_ip=`./ec2-graphite-ip`" "$@"
+ansible-playbook -i inventories/ec2/ setup-ec2-loadgen.yaml -e "collect_server_ip=`./ec2-graphite-ip`" -e "login_user=fedora" "$@"

--- a/ec2-setup-scylla.sh
+++ b/ec2-setup-scylla.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ansible-playbook -i inventories/ec2/ setup-ec2-scylla.yaml -e "collect_server_ip=`./ec2-graphite-ip`" -e "login_user=fedora" "$@"

--- a/group_vars/all
+++ b/group_vars/all
@@ -14,13 +14,13 @@ command: write
 command_options:
 output_format: cassandra-stress.{{command}}.{{load_name}}.{{ansible_date_time.date}}
 output_file: "{{output_format}}"
-remote_path: /home/{{login_user}}/
+remote_path: /home/{{loader_login}}/
 home_path: /tmp/cassandra-results/
 stress_options:
 populate: 1000000
 sleep_between_runs: 60
 threads: 250
-clean_data: true
+clean_data: false
 profile_git: false
 profile_dir: /tmp/cassandra-stress-profiles/
 profile_file: false

--- a/inventories/ec2/group_vars/all.yaml
+++ b/inventories/ec2/group_vars/all.yaml
@@ -6,13 +6,18 @@ region: us-west-2
 zone: us-west-2b
 
 cassandra_ami: ami-1cff962c # source: http://www.datastax.com/documentation/cassandra/2.0/cassandra/install/installAMILaunch.html
+scylla_ami: ami-79100849 # scylla 0.9.0
 loadgen_image: ami-3f68640f # ubuntu 14.04
 ubuntu_image: ami-3f68640f # ubuntu 14.04
 
+graphite_login: ubuntu
+cassandra_login: ubuntu
+scylla_login: fedora
+loader_login: fedora
+
 cluster_ami: true
 
-instance_type: m3.2xlarge
-#instance_type: m3.large
+instance_type: c3.8xlarge
 security_group: cassandra-security-group
 
 # graphite Server

--- a/inventories/ec2/hosts
+++ b/inventories/ec2/hosts
@@ -1,8 +1,9 @@
-[tag_Name_Cassandra]
+[tag_Name_DB]
 
 [tag_Name_CassandraLoadgen]
 
-[tag_server_origin]
+[tag_server_cassandra]
+[tag_server_scylla]
 
 [tag_stopped_true]
 
@@ -10,14 +11,18 @@
 
 [tag_Name_GraphiteServer]
 
-[Cassandra:children]
-tag_Name_Cassandra
+[DB:children]
+tag_Name_DB
 
 [CassandraLoadgen:children]
 tag_Name_CassandraLoadgen
 
-[Origin:children]
-tag_server_origin
+[Cassandra:children]
+tag_server_cassandra
+
+[Scylla:children]
+tag_server_scylla
+
 
 [Stopped:children]
 tag_stopped_true

--- a/prepare-cassandra.yaml
+++ b/prepare-cassandra.yaml
@@ -1,14 +1,14 @@
 - name: Prepare Cassandra nodes
-  hosts: NewCassandra
-  user: "{{login_user}}"
+  hosts: NewDB
+  user: "{{cassandra_login}}"
   roles:
     - { role: cassandra, sudo: yes, run_server: true, when: cluster_ami== 'false'}
     - { role: collectd-client, sudo: yes, tag: "stress", when: cluster_ami== 'false' }
 
 - name: Run Cassandra nodes
-  hosts: NewCassandra
+  hosts: NewDB
   serial: 1
-  user: "{{login_user}}"
+  user: "{{cassandra_login}}"
   tasks:
     - include: roles/cassandra/tasks/start.yaml
       when: not stopped

--- a/prepare-graphite.yaml
+++ b/prepare-graphite.yaml
@@ -1,6 +1,6 @@
 - name: Prepare Graphite
   hosts: GraphiteServer
-  user: "{{login_user}}"
+  user: "{{graphite_login}}"
   roles:
     - {role: graphite, sudo: yes }
     - {role: tessera, sudo: yes }

--- a/prepare-loadgen.yaml
+++ b/prepare-loadgen.yaml
@@ -1,7 +1,5 @@
 - name: Prepare load generator nodes
   hosts: CassandraLoadgen
-  user: "{{login_user}}"
+  user: "{{loader_login}}"
   roles:
-    - { role: cassandra, sudo: yes, run_server: false }
-    - loader
-    - { role: collectd-client, sudo: yes, tag: "stress", node: "loader-{{groups.CassandraLoadgen.index(inventory_hostname)}}" }
+     - { role: loader }

--- a/provision-loadgen.yaml
+++ b/provision-loadgen.yaml
@@ -13,7 +13,7 @@
         keypair: "{{key_name}}"
         group: "{{security_group}}"
         instance_type: "{{instance_type}}"
-        image: "{{ubuntu_image}}"
+        image: "{{scylla_ami}}"
         count: "{{ load_nodes}}"
         wait: yes
       register: ec2_load
@@ -31,4 +31,4 @@
           user: "{{setup_name}}"
 
     - name: Give everyone a minute or two
-      pause: seconds=60
+      pause: seconds=120

--- a/provision-scylla.yaml
+++ b/provision-scylla.yaml
@@ -1,12 +1,12 @@
 ---
-- name: Provision Cassandra cluster nodes on EC2
+- name: Provision Scylla cluster nodes on EC2
   hosts: localhost
   connection: local
   vars:
-    - cluster_name: CassandraCluster
+    - cluster_name: ScyllaCluster
 
   tasks:
-    - set_fact: image={{cassandra_ami}}
+    - set_fact: image={{scylla_ami}}
       when: cluster_ami
 
     - set_fact: image={{ubuntu_image}}
@@ -24,7 +24,7 @@
         instance_type: "{{instance_type}}"
         image: "{{image}}"
         count: "{{cluster_nodes}}"
-        user_data: "--clustername {{cluster_name}} --totalnodes {{cluster_nodes}} --version community --release {{cassandra_ver}}"
+        user_data: "--clustername {{cluster_name}} --totalnodes {{cluster_nodes}}"
         wait: yes
       register: ec2_cluster
 
@@ -65,7 +65,7 @@
       args:
         tags:
           Name: "DB"
-          server: "cassandra"
+          server: "scylla"
           stopped: "{{stopped}}"
           user: "{{setup_name}}"
 
@@ -78,4 +78,4 @@
       when: not add_node
 
     - name: Give everyone a minute or two
-      pause: seconds=60
+      pause: seconds=120

--- a/provision-scylla.yaml
+++ b/provision-scylla.yaml
@@ -32,33 +32,6 @@
       local_action: add_host name={{item.public_ip}} groupname=NewDB
       with_items: ec2_cluster.instances
 
-    - name: Add instances to private ip group
-      local_action: add_host name={{item.private_ip}} groupname=DBPrivate
-      with_items: ec2_cluster.instances
-
-    - name: Add instance 0 to seeds group
-      local_action: add_host name={{ec2_cluster.instances[0].id}} groupname=Seeds
-      when: not add_node
-
-    - name: Add instance 0 to seedsip group
-      local_action: add_host name={{groups.DBPrivate[0]}} groupname=SeedsIp
-      when: not add_node
-
-    - name: Add instance 1 to seeds group
-      local_action: add_host name={{ec2_cluster.instances[1].id}} groupname=Seeds
-      when: not add_node and ec2_cluster.instances | length > 1
-
-    - name: Add instance 1 to seedsip group
-      local_action: add_host name={{groups.DBPrivate[1]}} groupname=SeedsIp
-      when: not add_node and ec2_cluster.instances | length > 1
-
-
-    - debug: msg="SeedsIp {{groups.SeedsIp}}"
-      when: not add_node
-
-    - debug: msg="Seeds {{groups.Seeds}}"
-      when: not add_node
-
     - name: Tag instances
       local_action: ec2_tag resource={{item.id}} region={{region}} state=present
       with_items: ec2_cluster.instances
@@ -68,14 +41,6 @@
           server: "scylla"
           stopped: "{{stopped}}"
           user: "{{setup_name}}"
-
-    - name: Tag Seed instances
-      local_action: ec2_tag resource={{item}} region={{region}} state=present
-      with_items: groups.Seeds
-      args:
-        tags:
-          seed: "true"
-      when: not add_node
 
     - name: Give everyone a minute or two
       pause: seconds=120

--- a/roles/loader/tasks/main.yaml
+++ b/roles/loader/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- service: name=scylla-server enabled=yes state=stopped
+  sudo: yes
+
 - name: Gather facts
   action: ec2_facts
 
@@ -8,7 +11,7 @@
 - set_fact: index="{{ansible_ec2_ami_launch_index}}"
   when: ansible_ec2_ami_launch_index is defined
 
-- name: Tag instance as Stopped
+- name: Tag instance index
   local_action: ec2_tag resource={{id}} state=present region={{region}}
   when: ansible_ec2_ami_launch_index is defined
   args:

--- a/roles/scylla/tasks/start.yaml
+++ b/roles/scylla/tasks/start.yaml
@@ -1,0 +1,18 @@
+---
+- name: start scylla service
+  action: service name=scylla enabled=yes pattern=scylla state=restarted
+  sudo: yes
+- name: Gather facts
+  action: ec2_facts
+- set_fact:
+    id: "{{ansible_ec2_instance_id}}"
+  when: ansible_ec2_instance_id is defined
+- name: Tag instance as none stopped
+  local_action: ec2_tag resource={{id}} state=present region={{region}}
+  when: ansible_ec2_instance_id is defined
+  args:
+    tags:
+      stopped: "false"
+
+- name: Give everyone a minute or two
+  pause: seconds={{wait_after_adding_server}}

--- a/setup-ec2-scylla.yaml
+++ b/setup-ec2-scylla.yaml
@@ -1,0 +1,3 @@
+---
+- include: provision-scylla.yaml
+## - include: prepare-scylla.yaml

--- a/start_server.yaml
+++ b/start_server.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Start Service
-  hosts: "Cassandra:&Origin:&Stopped"
-  user: "{{login_user}}"
+  hosts: "DB:&Cassandra:&Stopped"
+  user: "{{cassandra_login}}"
   serial: 1
   tasks:
     - { include: roles/cassandra/tasks/start.yaml }

--- a/stop_server.yaml
+++ b/stop_server.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Stop Service
-  hosts: "Cassandra:&Origin"
-  user: "{{login_user}}"
+  hosts: "DB:&Cassandra"
+  user: "{{cassandra_login}}"
   tasks:
     - { include: roles/cassandra/tasks/stop.yaml }
 

--- a/stress.yaml
+++ b/stress.yaml
@@ -4,12 +4,13 @@
 
 - name: Run stress
   hosts: "CassandraLoadgen"
-  user: "{{login_user}}"
+  user: "{{loader_login}}"
   vars:
     iteration: 0 # overload me
+    server: "scylla"
   tasks:
 
-    - local_action: shell ./ec2-get-private-ips.py {{region}} {{setup_name}} "Cassandra" | cut -f2 -d' ' | sed s/^/\'/ | sed s/$/\'/ | sed ':a;N;$!ba;s/\n/,/g'
+    - local_action: shell ./ec2-get-private-ips.py {{region}} {{setup_name}} "DB" {{server}} | cut -f2 -d' ' | sed s/^/\'/ | sed s/$/\'/ | sed ':a;N;$!ba;s/\n/,/g'
       register: private_ips
       when: ip_list is not defined
 

--- a/stress_profile.yaml
+++ b/stress_profile.yaml
@@ -10,7 +10,7 @@
 
 - name: upload stress file to loaders
   hosts: "CassandraLoadgen"
-  user: "{{login_user}}"
+  user: "{{loader_login}}"
   tasks:
     - name: Creates directory
       file: path="~/{{profile_file | dirname }}" state=directory

--- a/terminate.yaml
+++ b/terminate.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Find Cassandra instance(s)
-  hosts: Cassandra
+  hosts: DB
   gather_facts: false
   tasks:
     - name: Create group


### PR DESCRIPTION
This pull request add support for testing Scylla cluster, to the existing cassandra server.
You can now run the following:

```
./ec2-setup-cassandra.sh
./ec2-setup-scylla.sh
./ec2-setup-loadgen.sh
./ec2-stress.sh 1 -e "load_name=cassandra.v1" -e "server=cassandra"
./ec2-stress.sh 1 -e "load_name=scylla.v1" -e "server=scylla"
```

The Scylla install is from AMI
The loader (cassandra-install) is using Scylla AMI, only the scylla service is stopped.

Server start, stop and cleans are not supported for Scylla yet.
