### PR TITLE
wait for instance ssh to be available before continue with provisioning

### DIFF
--- a/provision-db.yaml
+++ b/provision-db.yaml
@@ -46,6 +46,12 @@
       register: ec2_cluster
       with_dict: use_regions
 
+    - name: Wait for SSH to come up
+      wait_for: host={{item.1.public_ip}} port=22 delay=60 timeout=320 state=started
+      with_subelements:
+        - ec2_cluster.results
+        - instances
+
     - name: Add instances to host group
       local_action: add_host name={{item.1.public_ip}} groupname=NewDB
       with_subelements:
@@ -92,6 +98,3 @@
         tags:
           seed: "true"
       when: not ec2_multiregion|bool
-
-    - name: Give everyone a minute or two
-      pause: seconds=120

--- a/provision-loadgen.yaml
+++ b/provision-loadgen.yaml
@@ -18,6 +18,12 @@
       register: ec2_load
       with_dict: use_regions
 
+    - name: Wait for SSH to come up
+      wait_for: host={{item.1.public_ip}} port=22 delay=60 timeout=320 state=started
+      with_subelements:
+        - ec2_load.results
+        - instances
+
     - name: Add instances to host group
       local_action: add_host name={{item.1.public_ip}} groupname="CassandraLoadgen"
       with_subelements:
@@ -33,6 +39,3 @@
         tags:
           Name: "CassandraLoadgen"
           user: "{{setup_name}}"
-
-    - name: Give everyone a minute or two
-      pause: seconds=120


### PR DESCRIPTION
This request replace the 2 minute wait with a wait_for SSH port.
This is both more reliable metric for when its safe to continue, and often faster.
