### PR TITLE
Graphite server instance is no longer in use

### DIFF
--- a/ec2-add-node-to-cluster.sh
+++ b/ec2-add-node-to-cluster.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ansible-playbook -i inventories/ec2/ setup-ec2-cassandra.yaml -e "add_node=true" -e "use_reflector=false" -e "collect_server_ip=`./ec2-graphite-ip`" "$@"
+ansible-playbook -i inventories/ec2/ setup-ec2-cassandra.yaml -e "add_node=true" -e "use_reflector=false" "$@"

--- a/ec2-setup-loadgen.sh
+++ b/ec2-setup-loadgen.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ansible-playbook -i inventories/ec2/ setup-ec2-loadgen.yaml -e "collect_server_ip=`./ec2-graphite-ip`" -e "login_user=fedora" "$@"
+ansible-playbook -i inventories/ec2/ setup-ec2-loadgen.yaml -e "login_user=fedora" "$@"

--- a/inventories/ec2/group_vars/all.yaml
+++ b/inventories/ec2/group_vars/all.yaml
@@ -25,17 +25,10 @@ ec2_multiregion: false
 
 use_regions: "{%if ec2_multiregion | bool %}{{regions}}{%else%}{{first_regions}}{%endif%}" 
 
-graphite_login: ubuntu
 cassandra_login: ubuntu
 scylla_login: fedora
 loader_login: fedora
 
 instance_type: c3.8xlarge
 
-
-
 setup_name: "{{ansible_env.ANSIBLE_EC2_PREFIX}}"
-
-# graphite Server
-graphite_server_type: m3.large
-graphite_image: ami-29ebb519 # ubuntu

--- a/inventories/ec2/hosts
+++ b/inventories/ec2/hosts
@@ -9,8 +9,6 @@
 
 [tag_seed_true]
 
-[tag_Name_GraphiteServer]
-
 [DB:children]
 tag_Name_DB
 
@@ -26,9 +24,6 @@ tag_server_scylla
 
 [Stopped:children]
 tag_stopped_true
-
-[GraphiteServer:children]
-tag_Name_GraphiteServer
 
 [SeedsExIP:children]
 tag_seed_true


### PR DESCRIPTION
Graphite server was an old implementation of scylla-monitoring server.
The request clean traces for it which are no longer in use 
