### PR TITLE
Install scylla-tools on Fedora box

### DIFF
--- a/inventories/ec2/group_vars/all.yaml
+++ b/inventories/ec2/group_vars/all.yaml
@@ -6,6 +6,7 @@ regions:
     scylla_ami:  ami-36617657 # scylla 0.11
     loadgen_image: ami-3f68640f # ubuntu 14.04
     ubuntu_image: ami-3f68640f # ubuntu 14.04
+    fedora_ami: ami-05f4ed35 # fedora 22
     key_name: tzach-oregon
     security_group: cassandra-security-group
   us-east-1:
@@ -13,12 +14,13 @@ regions:
     scylla_ami:  ami-72196418 # scylla 0.11
     loadgen_image: ami-d05e75b8 # ubuntu 14.04
     ubuntu_image: ami-d05e75b8 # ubuntu 14.04
+    fedora_ami: ami-a51564c0 # fedora 22
     key_name: tzach-virginia
     security_group: cassandra-security-group
 
 # list of only the first region
 first_regions:
-  us-west-2: "{{regions['us-west-2']}}"
+  us-east-1: "{{regions['us-east-1']}}"
 
 
 ec2_multiregion: false

--- a/inventories/ec2/group_vars/all.yaml
+++ b/inventories/ec2/group_vars/all.yaml
@@ -20,7 +20,7 @@ regions:
 
 # list of only the first region
 first_regions:
-  us-east-1: "{{regions['us-east-1']}}"
+  us-west-2: "{{regions['us-west-2']}}"
 
 
 ec2_multiregion: false

--- a/provision-loadgen.yaml
+++ b/provision-loadgen.yaml
@@ -12,7 +12,7 @@
         keypair: "{{item.value.key_name}}"
         group: "{{item.value.security_group}}"
         instance_type: "{{instance_type}}"
-        image: "{{item.value.scylla_ami}}"
+        image: "{{item.value.fedora_ami}}"
         count: "{{ load_nodes}}"
         wait: yes
       register: ec2_load

--- a/roles/loader/tasks/main.yaml
+++ b/roles/loader/tasks/main.yaml
@@ -1,5 +1,10 @@
 ---
-- service: name=scylla-server enabled=yes state=stopped
+- name: Update repo
+  action: template src=scylla.repo dest=/etc/yum.repos.d/scylla.repo owner=root group=root
+  sudo: yes
+
+- name: Install Scylla tools
+  dnf: name=scylla-tools
   sudo: yes
 
 - name: Gather facts

--- a/roles/loader/templates/scylla.repo
+++ b/roles/loader/templates/scylla.repo
@@ -1,0 +1,11 @@
+[scylla]
+name=Scylla for Fedora $releasever - $basearch
+baseurl=https://s3.amazonaws.com/downloads.scylladb.com/rpm/fedora/$releasever/$basearch/
+enabled=1
+gpgcheck=0
+
+[scylla-generic]
+name=Scylla for Fedora $releasever 
+baseurl=https://s3.amazonaws.com/downloads.scylladb.com/rpm/fedora/$releasever/noarch/
+enabled=1
+gpgcheck=0


### PR DESCRIPTION
Loader machine need a Scylla compatible version of cassandra-stress. 
Till now loader machine use Scylla AMI, which runs Scylla service automatically, and than stops by the loader - an error prune process.

This request use a Fedora AMI instead, installing scylla-tools rpm for the cassandra-stress.
