### PR TITLE
add collectd network plugin

### DIFF
--- a/roles/scylla-collectd-client/tasks/main.yaml
+++ b/roles/scylla-collectd-client/tasks/main.yaml
@@ -12,6 +12,9 @@
 - name: install collectd client
   dnf: name=collectd state=latest
 
+- name: install collectd-netlink plugin
+  dnf: name=collectd-netlink state=latest
+
 - action: template src=collectd-client.conf dest=/etc/collectd.conf owner=root group=root
   notify:
     - restart collectd


### PR DESCRIPTION
In order to see network metrics, we need to install the collectd plugin. Technically,
we could install this en lieu of collectd, as I am pretty sure it would pull collectd
as a dependency. But in my opinion, installing it after collectd makes it clearer what
is going on, even though it is slightly less efficient.

Signed-off-by: Glauber Costa glommer@scylladb.com
