### PR TITLE
scylla AMI data dir is /data

### DIFF
--- a/roles/scylla-config/tasks/clean.yaml
+++ b/roles/scylla-config/tasks/clean.yaml
@@ -1,3 +1,3 @@
 - service: name=scylla-server enabled=yes state=stopped
-- shell: rm -rf {{data_dir}}/data
-- shell: rm -rf {{data_dir}}/commitlog
+- shell: rm -rf {{data_dir}}/data/*
+- shell: rm -rf {{data_dir}}/commitlog/*

--- a/roles/scylla-config/vars/main.yaml
+++ b/roles/scylla-config/vars/main.yaml
@@ -1,7 +1,7 @@
 internal_ip: "{{ansible_all_ipv4_addresses[0]}}"
 auto_bootstrap: "false"
 num_tokens: 256
-data_dir: /var/lib/scylla/
+data_dir: /data
 
 snitch: "Ec2Snitch"
 


### PR DESCRIPTION
Scylla AMI data directory is /data, not /var/lib/scylla/
When role/scylla-config apply (for example in multi region) the uploaded scylla.yaml file will override the right (first) with the wrong value (second)
This request fix this.
