### PR TITLE
enable clean_data stress option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Scylla servers launch from Scylla AMI, base on Fedora 22 (login fedora)
   **options**
   * ```-e "cluster_nodes=2"``` - number of nodes **per region** (default 2)
   * ```-e "instance_type=c3.8xlarge"``` - type of EC2 instance
-  * ```-e "ec2_multiregion=true"```- a multi region EC2 deployment **[does not work yet!]**
+  * ```-e "ec2_multiregion=true"```- a multi region EC2 deployment
   * ```-e "collectd_server=your-collectd-server-ip"``` - collectd server to collect metric. See [scylla-monitoring](https://github.com/scylladb/scylla-monitoring) for an example monitoring server
 
 Server are created with EC2 name *DB*, and tag "server=Scylla"
@@ -154,6 +154,7 @@ notation. Examples below:
 * ```-e "command_options=duration=60m"```
 * ```-e "threads=200"```
 * ```-e "profile_dir=/tmp/cassandra-stress-profiles/" -e "profile_file=cust_a/users/users1.yaml" -e "command_options=ops\\(insert=1\\)"```
+* ```-e "clean_data=true"``` - clean all data from DB servers and restart them before starting the stress
 
 Make sure **load name is unique**  so the new results will not
 override an old run in the same day.
@@ -191,7 +192,6 @@ The next stress test will restart the Cassandra service.
 
 ## Todo
 Scylla cluster does not yet support:
-* clean_data option, to clean data files before each stress
 * ec2-add-node-to-cluster, ec2-start-server.sh and ec2-stop-server.sh
 
 

--- a/clean_data.yaml
+++ b/clean_data.yaml
@@ -1,13 +1,31 @@
 ---
-- name: Clean Data
-  hosts: "Cassandra:&Origin:!Stopped"
+- name: Clean Data Cassandra
+  hosts: "Cassandra:!Stopped"
   user: "{{cassandra_login}}"
   tasks:
-    - { include: roles/cassandra-config/tasks/clean.yaml, sudo: yes , when: clean_data | bool }
+    - include_vars: roles/cassandra-config/vars/main.yaml
+      when: server == "Cassandra" and clean_data | bool
+    - { include: roles/cassandra-config/tasks/clean.yaml, sudo: yes , when: server == "Cassandra" and clean_data | bool }
 
-- name: Restart Service - one by one
-  hosts: "Cassandra:&Origin:!Stopped"
+- name: Restart Cassandra Service - one by one
+  hosts: "Cassandra:!Stopped"
   user: "{{cassandra_login}}"
   serial: 1
   tasks:
-    - { include: roles/cassandra-config/tasks/start.yaml, when: clean_data | bool }
+    - { include: roles/cassandra-config/tasks/start.yaml, when: server == "Cassandra" and  clean_data | bool }
+
+- name: Clean Data Scylla
+  hosts: "Scylla:!Stopped"
+  user: "{{scylla_login}}"
+  tasks:
+    - include_vars: roles/scylla-config/vars/main.yaml
+      when: server == "Scylla" and clean_data | bool
+    - { include: roles/scylla-config/tasks/clean.yaml, sudo: yes , when: server == "Scylla" and clean_data | bool }
+
+- name: Restart Scylla Service - one by one
+  hosts: "Scylla:!Stopped"
+  user: "{{scylla_login}}"
+  serial: 1
+  tasks:
+    - { include: roles/scylla-config/tasks/start.yaml, when: server == "Scylla" and clean_data | bool }
+

--- a/roles/cassandra-config/tasks/clean.yaml
+++ b/roles/cassandra-config/tasks/clean.yaml
@@ -1,4 +1,8 @@
 ---
 - service: name=cassandra enabled=yes pattern=cassandra state=stopped
-- shell: rm -rf {{data_dir}}/
+- debug: msg="clean {{data_dir}}"
+- file: path={{data_dir}}/data state=absent
+- file: path={{data_dir}}/commitlog state=absent
+- file: path={{data_dir}}/saved_caches state=absent
+
 

--- a/roles/scylla-config/tasks/clean.yaml
+++ b/roles/scylla-config/tasks/clean.yaml
@@ -1,3 +1,6 @@
 - service: name=scylla-server enabled=yes state=stopped
-- shell: rm -rf {{data_dir}}/data/*
-- shell: rm -rf {{data_dir}}/commitlog/*
+- debug: msg="clean {{data_dir}}"
+- file: path={{data_dir}}/data state=absent
+- file: path={{data_dir}}/commitlog state=absent
+- file: path={{data_dir}}/data state=directory owner=scylla group=scylla
+- file: path={{data_dir}}/commitlog state=directory owner=scylla group=scylla

--- a/stress.yaml
+++ b/stress.yaml
@@ -1,5 +1,5 @@
 ---
-- include: clean_data.yaml # TBD clean only Cassandra, not Scylla
+- include: clean_data.yaml
 - include: stress_profile.yaml
 
 - name: Run stress


### PR DESCRIPTION
`-e "clean_data=true"` stress option now works for both Cassandra and Scylla
