### PR TITLE
Speedup setup

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -26,7 +26,7 @@ profile_dir: /tmp/cassandra-stress-profiles/
 #others
 s3_buckt: cassandra.test
 upload_to_s3: false
-wait_after_adding_server: 120
+wait_after_adding_server: 10
 
 collectd_server_port: 25826
 

--- a/prepare-cassandra.yaml
+++ b/prepare-cassandra.yaml
@@ -17,8 +17,7 @@
 
 - name: Run Cassandra nodes
   hosts: NewDB
-  serial: 1
   user: "{{cassandra_login}}"
   tasks:
     - include: roles/cassandra-config/tasks/start.yaml
-      when: ec2_multiregion|bool or not stopped|bool
+      when: not stopped|bool and (ec2_multiregion|bool or collectd_server is defined)

--- a/prepare-scylla.yaml
+++ b/prepare-scylla.yaml
@@ -17,8 +17,7 @@
 
 - name: Run scylla nodes
   hosts: NewDB
-  serial: 1
   user: "{{scylla_login}}"
   tasks:
     - include: roles/scylla-config/tasks/start.yaml
-      when: ec2_multiregion|bool or not stopped|bool or collectd_server is defined
+      when: not stopped|bool and (ec2_multiregion|bool or collectd_server is defined)

--- a/provision-db.yaml
+++ b/provision-db.yaml
@@ -37,6 +37,11 @@
         image: "{{item.value[image]}}"
         count: "{{cluster_nodes}}"
         user_data: "{{user_data}}"
+        instance_tags:
+          Name: "DB"
+          server: "{{db}}"
+          stopped: "{{stopped}}"
+          user: "{{setup_name}}"
         volumes:
         - device_name: /dev/sdb
           ephemeral: ephemeral0
@@ -78,18 +83,6 @@
     - name: Add instance 0 public ip as seed
       local_action: add_host name={{groups.NewDB[0]}} groupname=SeedsIp
       when: ec2_multiregion|bool 
-
-    - name: Tag instances
-      local_action: ec2_tag resource={{item.1.id}} region={{item.1.region}} state=present
-      with_subelements:
-        - ec2_cluster.results
-        - instances
-      args:
-        tags:
-          Name: "DB"
-          server: "{{db}}"
-          stopped: "{{stopped}}"
-          user: "{{setup_name}}"
 
     - name: Tag Seed instances
       local_action: ec2_tag resource={{item}} region={{ec2_cluster.results[0].instances[0].region}} state=present

--- a/provision-loadgen.yaml
+++ b/provision-loadgen.yaml
@@ -14,6 +14,9 @@
         instance_type: "{{instance_type}}"
         image: "{{item.value.fedora_ami}}"
         count: "{{ load_nodes}}"
+        instance_tags:
+          Name: "CassandraLoadgen"
+          user: "{{setup_name}}"
         wait: yes
       register: ec2_load
       with_dict: use_regions
@@ -29,13 +32,3 @@
       with_subelements:
         - ec2_load.results
         - instances
-
-    - name: Tag instances
-      local_action: ec2_tag resource={{item.1.id}} region={{item.1.region}} state=present
-      with_subelements:
-        - ec2_load.results
-        - instances
-      args:
-        tags:
-          Name: "CassandraLoadgen"
-          user: "{{setup_name}}"


### PR DESCRIPTION
The request shorten the time to set up a Scylla / Cassandra cluster by:
- only restart DB service when required (config or collectd change)
- restart all server in parallel (safe, since there is no data yet)
- tag EC2 instances in the launch command
