### PR TITLE
add subnet id as config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,16 @@ export ANSIBLE_EC2_PREFIX=tzach
 ### Setup
 The default setup is using one region for all nodes, and the reflector to attache them to a cluster.
 To test a multi region setup, use ```-e "ec2_multiregion=true"``` as an extra parameter for the setup commands below.
-The default EC2 regions are define in ```inventories/ec2/group_vars/all.yaml```, with the AMI, security group, and key-pair per region. **You must update the key-pair** to your own.
+The default EC2 regions are define in ```inventories/ec2/group_vars/all.yaml```, with the AMI, security group, and key-pair per region. **You must update the key-pair, security_group and vpc_subnet_id** to your own.
 
 #### Create security group
+**Do this only if you do not already have a security group you can use**
 The following will create a EC2 security group called "cassandra-security-group", which is later used for all EC2 servers.
 ```
 ansible-playbook -i inventories/ec2/ configure-security-group.yaml -e "security_group=cassandra-security-group" -e "region=your-ec2-region" -e "vpc_id=your-vpc"
 ```
+Make sure to set one of the VPC subnet IDs on inventories/ec2/group_vars/all.yaml
+
 You only need to run this once. Once security group exists, there is no need to repeat this step. You can use a different security group by adding ```-e "security_group=your_group_name"``` option to all ec2-setup-* scripts below.
 
 #### Launch Scylla cluster

--- a/inventories/ec2/group_vars/all.yaml
+++ b/inventories/ec2/group_vars/all.yaml
@@ -7,20 +7,23 @@ regions:
     ubuntu_image: ami-3f68640f # ubuntu 14.04
     fedora_ami: ami-05f4ed35 # fedora 22
     key_name: tzach-oregon
-    security_group: cassandra-security-group
+    security_group: cassandra-security-group # make sure security group is corralte to vpc
+    vpc_subnet_id: subnet-5207ee37
   us-east-1:
     cassandra_ami: ami-ada2b6c4 # DataStax Auto-Clustering AMI 2.5.1-hvm
     scylla_ami:  ami-e08ccb8a # scylla 0.12
     ubuntu_image: ami-d05e75b8 # ubuntu 14.04
     fedora_ami: ami-a51564c0 # fedora 22
     key_name: tzach-virginia
-    security_group: cassandra-security-group
+    security_group: cassandra-security-group # make sure security group is corralte to vpc
+    vpc_subnet_id: subnet-ec4a72c4
   us-west-1:
     cassandra_ami: ami-3cf7c979 # DataStax Auto-Clustering AMI 2.5.1-hvm
     scylla_ami: ami-f0026b90 # scylla 0.12
     fedora_ami: ami-c9e21e8d # fedora 22
     key_name: tzach-california
-    security_group: cassandra-security-group
+    security_group: cassandra-security-group # make sure security group is corralte to vpc
+    vpc_subnet_id: subnet-10a04c75
 
 # subset of the region use when ec2_multiregion is false
 first_regions:

--- a/provision-db.yaml
+++ b/provision-db.yaml
@@ -33,6 +33,8 @@
         region: "{{item.key}}"
         keypair: "{{item.value.key_name}}"
         group: "{{item.value.security_group}}"
+        vpc_subnet_id: "{{item.value.vpc_subnet_id}}"
+        assign_public_ip: yes
         instance_type: "{{instance_type}}"
         image: "{{item.value[image]}}"
         count: "{{cluster_nodes}}"

--- a/provision-loadgen.yaml
+++ b/provision-loadgen.yaml
@@ -11,6 +11,8 @@
         region: "{{item.key}}"
         keypair: "{{item.value.key_name}}"
         group: "{{item.value.security_group}}"
+        vpc_subnet_id: "{{item.value.vpc_subnet_id}}"
+        assign_public_ip: yes
         instance_type: "{{instance_type}}"
         image: "{{item.value.fedora_ami}}"
         count: "{{ load_nodes}}"


### PR DESCRIPTION
This request add a new parameter to the EC2 configuration: vpc_subnet_id
All instances (DB, loaders) will be launch within the VPC.

In addition instances require a public IP, which might not be mandatory, but it is useful.
