### PR TITLE
do not use different population per loader

### DIFF
--- a/roles/loader/tasks/main.yaml
+++ b/roles/loader/tasks/main.yaml
@@ -6,21 +6,3 @@
 - name: Install Scylla tools
   dnf: name=scylla-tools
   sudo: yes
-
-- name: Gather facts
-  action: ec2_facts
-
-- set_fact:
-    id: "{{ansible_ec2_instance_id}}"
-    region: "{{ ansible_ec2_placement_availability_zone | regex_replace('(.*[1-9])(.)', '\\\\1' ) }}"
-  when: ansible_ec2_instance_id is defined
-
-- set_fact: index="{{ansible_ec2_ami_launch_index}}"
-  when: ansible_ec2_ami_launch_index is defined
-
-- name: Tag instance index
-  local_action: ec2_tag resource={{id}} state=present region={{region}}
-  when: ansible_ec2_ami_launch_index is defined
-  args:
-    tags:
-      index: "{{index}}"

--- a/stress.yaml
+++ b/stress.yaml
@@ -9,6 +9,8 @@
     iteration: 0 # overload me
     server: "Scylla"
   tasks:
+    - set_fact: loader_ip="{{ansible_eth0.ipv4.address}}"
+
     - name: Gather facts
       action: ec2_facts
 
@@ -24,9 +26,6 @@
 
     - debug: msg="ip_list is {{ip_list}}"
 
-    - set_fact: index={{ec2_tag_index}}
-      when: index is not defined
-
     - set_fact: taskset="taskset -c {{load_cpus}}"
       when: load_cpus is defined
 
@@ -40,13 +39,9 @@
       when: load_cpus is defined
       sudo: yes
 
-    - set_fact: log_file="{{remote_path}}{{output_file}}.{{ec2_region}}.{{index}}"
-    - set_fact: range_start={{1 + (populate|int) * (index|int) }}
-    - set_fact: range_end={{(populate|int) * (1 + (index|int)) }}
-    - set_fact: range="{{range_start}}..{{range_end}}"
-    - debug: msg="client key range {{range}}"
+    - set_fact: log_file="{{remote_path}}{{output_file}}.{{ec2_region}}.{{loader_ip}}"
 
-    - shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress {{command}} {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data -pop seq={{range}} {{stress_options}}
+    - shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress {{command}} {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
       when: profile_file is undefined
       ignore_errors: True
 
@@ -54,8 +49,8 @@
       when: profile_file is defined
       ignore_errors: True
 
-    - fetch: src={{log_file}}.{{iteration}}.data dest={{home_path}}{{output_file}}.{{ec2_region}}.{{index}}.{{iteration}}.data flat=yes
+    - fetch: src={{log_file}}.{{iteration}}.data dest={{home_path}}{{output_file}}.{{ec2_region}}.{{loader_ip}}.{{iteration}}.data flat=yes
       ignore_errors: True
 
-    - local_action: s3 bucket={{s3_buckt}} object={{output_file}}/{{output_file}}.{{ec2_region}}.{{index}}.{{iteration}} src={{home_path}}{{output_file}}.{{index}}.{{iteration}} mode=put
+    - local_action: s3 bucket={{s3_buckt}} object={{output_file}}/{{output_file}}.{{ec2_region}}.{{loader_ip}}.{{iteration}} src={{home_path}}{{output_file}}.{{loader_ip}}.{{iteration}} mode=put
       when: upload_to_s3

--- a/sum-results.sh
+++ b/sum-results.sh
@@ -2,7 +2,8 @@
 
 load=$1
 
-tail -16 $load.*.0.1.data | cut -f1 -d: > $load.sum
+#tail -16 $load.*.0.1.data | cut -f1 -d: > $load.sum
+ls $load.*.data | head -1 | xargs tail -16 | cut -f1 -d: > $load.sum
 
 for f in $load.*.data; do
     cut -f2- -d: $f | tail -16 | sed 's/\[.*\]//' | paste -d, $load.sum - > $load.sum.tmp


### PR DESCRIPTION
Using different population per loader is not align with our benchmarks[1].
Removing it simplify the code, and remove the need to assign a unique index for each loader.

[1] http://www.scylladb.com/technology/cassandra-vs-scylla-benchmark-cluster-1/
