### PR TITLE
re enable cassandra node add

### DIFF
--- a/prepare-cassandra.yaml
+++ b/prepare-cassandra.yaml
@@ -12,7 +12,7 @@
   user: "{{cassandra_login}}"
   roles:
     - { role: cassandra-install, sudo: yes, when: not use_db_ami|bool}
-    - { role: cassandra-config, sudo: yes, when: ec2_multiregion|bool or not use_db_ami|bool}
+    - { role: cassandra-config, sudo: yes, when: ec2_multiregion|bool or add_node|bool or not use_db_ami|bool}
     - { role: collectd-client, sudo: yes, tag: "stress", when: collectd_server is defined}
 
 - name: Run Cassandra nodes

--- a/stress.yaml
+++ b/stress.yaml
@@ -19,7 +19,7 @@
         user_group: "tag_user_{{setup_name}}"
 
     - debug: msg="{{ hostvars[item].ec2_private_ip_address }}"
-      with_items: groups.DB | intersect (groups.{{region_group}}) | intersect (groups.{{user_group}}) | intersect (groups.{{server}})
+      with_items: groups.DB | intersect (groups.{{region_group}}) | intersect (groups.{{user_group}}) | intersect (groups.{{server}}) | difference(groups.Stopped)
       register: output
 
     - set_fact: ip_list={{ output.results|map(attribute='msg') | join(',') }}


### PR DESCRIPTION
Fix two bugs that stop cloud burst use case from working with Cassandra, in particular
`ec2-add-node-to-cluster.sh` and `./ec2-start-server.sh` 
