### PR TITLE
do not call ec2 dynamic inventory on setup

### DIFF
--- a/ec2-setup-cassandra.sh
+++ b/ec2-setup-cassandra.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ansible-playbook -i inventories/ec2/ setup-ec2-cassandra.yaml "$@"
+ansible-playbook setup-ec2-cassandra.yaml -e "@inventories/ec2/group_vars/all.yaml" "$@"

--- a/ec2-setup-loadgen.sh
+++ b/ec2-setup-loadgen.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ansible-playbook -i inventories/ec2/ setup-ec2-loadgen.yaml -e "login_user=fedora" "$@"
+ansible-playbook setup-ec2-loadgen.yaml -e "@inventories/ec2/group_vars/all.yaml" "$@"

--- a/ec2-setup-scylla.sh
+++ b/ec2-setup-scylla.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ansible-playbook -i inventories/ec2/ setup-ec2-scylla.yaml -e "login_user=fedora" "$@"
+ansible-playbook setup-ec2-scylla.yaml -e "@inventories/ec2/group_vars/all.yaml" "$@"


### PR DESCRIPTION
Replace the call to ec2 dynamic inventory to a call to ec2 parameters file in all the setup scripts.
This is better:
- setup scripts do not use the dynamic info, downloading ec2 state is a waste of time
- fix #27 

Calling the dynamic ec2 inventory  is still useful when a playbook need to interact with running instances, like stress.yaml
