### PR TITLE
avg-from-sum.sh: Remove bashism

### DIFF
--- a/avg-from-sum.sh
+++ b/avg-from-sum.sh
@@ -5,8 +5,7 @@
 file=$1
 sumfile=$1.sum
 
-files=($file.*.data)
-numfiles=`expr ${#files[@]}`
+numfiles=`ls -l $file.*.data | wc -l`
 
 head -14 $sumfile | cut -f2- -d: | sed 's/,/ +/g' | bc | xargs -i echo "{} / $numfiles" | bc > $sumfile.tmp-avg
 head -14 $sumfile | cut -f1 -d: | paste -d: - $sumfile.tmp-avg > $file.avg


### PR DESCRIPTION
Fedora uses bash as /bin/sh, so frequently when developing
shell scripts on that distro it's easy to slip in some
bashisms [1] into the code. Let's replace the method of
finding the number of data files in that script [1]
for a far less elegant, yet more dependable method.

[1] http://www.yourdictionary.com/bashism
[2] That script uses bash arrays, not compatible with
    Ubuntu's default shell, /bin/dash.

Signed-off-by: Lucas Meneghel Rodrigues lmr@scylladb.com
