### PR TITLE
revert the user group search

### DIFF
--- a/roles/cassandra-config/tasks/main.yaml
+++ b/roles/cassandra-config/tasks/main.yaml
@@ -12,7 +12,7 @@
 # use exisiting nodes as seed, even if they are not
 # TBD find public IP in case of multi region
 - command: echo "{{ hostvars[item].ec2_private_ip_address }}"
-  with_items: groups.Cassandra | intersect (groups.{{user_group}})
+  with_items: groups.Cassandra
   register: output
   changed_when: no
   when: add_node

--- a/roles/scylla-config/tasks/main.yaml
+++ b/roles/scylla-config/tasks/main.yaml
@@ -11,7 +11,7 @@
 # use exisiting nodes as seed, even if they are not
 # TBD find public IP in case of multi region
 - command: echo "{{ hostvars[item].ec2_private_ip_address }}"
-  with_items: groups.Scylla | intersect (groups.{{user_group}})
+  with_items: groups.Scylla
   register: output
   changed_when: no
   when: add_node


### PR DESCRIPTION
This request revert the update made in https://github.com/scylladb/cassandra-test-and-deploy/pull/62
With out this change, the following fail in normal cluster setup:

```
- command: echo "{{ hostvars[item].ec2_private_ip_address }}"
  with_items: groups.Scylla | intersect (groups.{{user_group}})
  register: output
  changed_when: no
  when: add_node
```

even when add_node was false!
Ansible first try to evaluate the with_item, than the when condition.
