### PR TITLE
create stress table once

### DIFF
--- a/stress.yaml
+++ b/stress.yaml
@@ -41,11 +41,15 @@
 
     - set_fact: log_file="{{remote_path}}{{output_file}}.{{ec2_region}}.{{loader_ip}}"
 
-    - shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress {{command}} {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
+    - name: run cassandra-stress withe one insert to create the table
+      shell: cassandra-stress write n=1 no-warmup -node {{ip_list}} -rate threads=1  {{stress_options}}
+      run_once: true
+
+    - shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress {{command}} no-warmup {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
       when: profile_file is undefined
       ignore_errors: True
 
-    - shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress user profile={{profile_file}} {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
+    - shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress user profile={{profile_file}} no-warmup {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
       when: profile_file is defined
       ignore_errors: True
 


### PR DESCRIPTION
running stress from multiple loader at once is error prune when all loader try to create the same table at the same time.
This request runs a very short stress once and in advance.
