### PR TITLE
move to scylla 0.18 AMI, and use local collectd proxy to send metrics

### DIFF
--- a/inventories/ec2/group_vars/all.yaml
+++ b/inventories/ec2/group_vars/all.yaml
@@ -4,7 +4,7 @@ regions:
   us-west-2 :
     region_name: us-west-2
     cassandra_ami: ami-1cff962c # DataStax Auto-Clustering AMI 2.5.1-hvm
-    scylla_ami: ami-4431d024  # scylla 0.17
+    scylla_ami: ami-d56d8eb5  # scylla 0.18
     ubuntu_image: ami-3f68640f # ubuntu 14.04
     fedora_ami: ami-05f4ed35 # fedora 22
     key_name: tzach-oregon
@@ -13,7 +13,7 @@ regions:
   us-east-1:
     region_name: us-east-1
     cassandra_ami: ami-ada2b6c4 # DataStax Auto-Clustering AMI 2.5.1-hvm
-    scylla_ami: ami-4a597220  # scylla 0.17
+    scylla_ami: ami-e7e4d28d  # scylla 0.18
     ubuntu_image: ami-d05e75b8 # ubuntu 14.04
     fedora_ami: ami-a51564c0 # fedora 22
     key_name: tzach-virginia
@@ -22,7 +22,7 @@ regions:
   us-west-1:
     region_name: us-west-1
     cassandra_ami: ami-3cf7c979 # DataStax Auto-Clustering AMI 2.5.1-hvm
-    scylla_ami: ami-1da7d17d # scylla 0.17
+    scylla_ami: ami-be84f5de # scylla 0.18
     fedora_ami: ami-c9e21e8d # fedora 22
     key_name: tzach-california
     security_group: cassandra-security-group # make sure security group is corralte to vpc

--- a/roles/scylla-collectd-client/tasks/main.yaml
+++ b/roles/scylla-collectd-client/tasks/main.yaml
@@ -3,18 +3,6 @@
 
 - set_fact: node="scylla-{{ansible_hostname }}"
 
-- name: set collectd server when SCYLLA_ARGS already have parameters
-  replace: dest=/etc/sysconfig/scylla-server
-           backup=yes
-           regexp='SCYLLA_ARGS="(.*)"'
-           replace='SCYLLA_ARGS="\1 --collectd-address={{collectd_server}}:{{collectd_server_port}} --collectd=1 --collectd-hostname={{node}} --collectd-poll-period 3000"'
-
-- name: set collectd server set collectd server when SCYLLA_ARGS is empty
-  replace: dest=/etc/sysconfig/scylla-server
-           backup=yes
-           regexp="SCYLLA_ARGS=$"
-           replace='SCYLLA_ARGS="--collectd-address={{collectd_server}}:{{collectd_server_port}} --collectd=1 --collectd-hostname={{node}} --collectd-poll-period 3000"'
-
 - name: install collectd client
   yum: name=collectd state=latest
 

--- a/roles/scylla-collectd-client/templates/collectd-client.conf
+++ b/roles/scylla-collectd-client/templates/collectd-client.conf
@@ -22,8 +22,16 @@ LoadPlugin cpu
 
 Interval 1
 <Plugin "network">
+  Listen "127.0.0.1"
   Server "{{collectd_server}}" "{{collectd_server_port}}"
+  Forward true
+</Plugin>
+
+<Plugin unixsock>
+    SocketFile "/var/run/collectd-unixsock"
+    SocketGroup "wheel"
+    SocketPerms "0660"
+    DeleteSocket false
 </Plugin>
 
 Include "/etc/collectd.d"
-


### PR DESCRIPTION
Starting from AMI 0.18, Scylla always write metrics to a local collectd.
To send metrics to a remote server, collectd is used as a proxy, instead of Scylla itself send it to a remote server.
This simplify the setup, and will be used later for scylla-top
