### PR TITLE
Upload key to ec2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,25 +32,26 @@ export AWS_ACCESS_KEY_ID=<...>
 export AWS_SECRET_ACCESS_KEY=<...>
 ```
 
+* Make sure your server use a unique name on EC2, by setting ANSIBLE_EC2_PREFIX
+```
+export ANSIBLE_EC2_PREFIX=tzach
+```
+
 * Make sure you have a ssh-agent running:
 
 ```
 eval `ssh-agent -s`
 ```
 
-* Make sure your EC2 SSH keys for each EC2 region is included in the keychain:
+* By default, `~/.ssh/id_rsa.pub` will be used as your EC2 key. if you
+  do not have such a key, [generate one](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/). to use a different key, override this with ```-e "public_key_path=your-path.pub"```
 
+* Add it to your agent
 ```sh
-ssh-add <key-file>
+ssh-add `~/.ssh/id_rsa.pub`
 ```
+(use your key)
 
-key-file should have the right permission
-
-```
-chmod 200 key-file
-```
-
-**You should do it for each of EC2 region!**
 
 * Avoid prompting for SSH key confirmation by
 ```
@@ -65,14 +66,9 @@ Update boto if required
 sudo pip install --upgrade boto
 ```
 
-* Make sure your server use a unique name on EC2, by setting ANSIBLE_EC2_PREFIX
-```
-export ANSIBLE_EC2_PREFIX=tzach
-```
-
 * The default EC2 regions are define in
-```inventories/ec2/group_vars/all.yaml```, with the *AMI*, *security group*, and *key-name* per region.
-**You must update the key_name, security_group and vpc_subnet_id** to your own.
+```inventories/ec2/group_vars/all.yaml```, with the *AMI*, *security group*.
+**You must update the security_group and vpc_subnet_id** to your own.
 
 #### Create security group
 **Do this only if you do not already have a security group you can use**

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ eval `ssh-agent -s`
 ```
 
 * By default, `~/.ssh/id_rsa.pub` will be used as your EC2 key. if you
-  do not have such a key, [generate one](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) with `ssh-keygen -y`. to use a different key, override this with ```-e "public_key_path=your-path.pub"```
+  do not have such a key, [generate one](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) with `ssh-keygen`. to use a different key, override this with ```-e "public_key_path=your-path.pub"```
 
 make sure permission are correct:
 ```
@@ -54,7 +54,7 @@ chmod 700 ~/.ssh/id_rsa.pub
 
 * Add it to your agent
 ```sh
-ssh-add `~/.ssh/id_rsa.pub`
+ssh-add ~/.ssh/id_rsa.pub
 ```
 (use your key)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ eval `ssh-agent -s`
 ```
 
 * By default, `~/.ssh/id_rsa.pub` will be used as your EC2 key. if you
-  do not have such a key, [generate one](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/). to use a different key, override this with ```-e "public_key_path=your-path.pub"```
+  do not have such a key, [generate one](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) with `ssh-keygen -y`. to use a different key, override this with ```-e "public_key_path=your-path.pub"```
+
+make sure permission are correct:
+```
+chmod 700 ~/.ssh
+chmod 700 ~/.ssh/id_rsa.pub
+```
 
 * Add it to your agent
 ```sh

--- a/create-keys.yaml
+++ b/create-keys.yaml
@@ -1,0 +1,19 @@
+---
+- name: Provision Scylla cluster nodes on EC2
+  hosts: localhost
+  connection: local
+
+  vars:
+    material: "{{ lookup('file', public_key_path) }}"
+
+  tasks:
+
+    - debug: msg="{{material}}"
+
+    - name: Create an EC2 key
+      ec2_key:
+        name: "{{setup_name}}-test-and-deploy-key"
+        region:  "{{item.value.region_name}}"
+        key_material: "{{ material }}"
+        state: present
+      with_dict: use_regions

--- a/create-keys.yaml
+++ b/create-keys.yaml
@@ -8,8 +8,6 @@
 
   tasks:
 
-    - debug: msg="{{material}}"
-
     - name: Create an EC2 key
       ec2_key:
         name: "{{setup_name}}-test-and-deploy-key"

--- a/ec2-stress.sh
+++ b/ec2-stress.sh
@@ -6,6 +6,6 @@ shift
 for i in `seq 1 $iterations`;
 do
     echo "iteration $i"
-    ansible-playbook -i inventories/ec2/ stress.yaml --limit "tag_user_`echo $ANSIBLE_EC2_PREFIX`"  -e "iteration=$i" -e "setup_name=`echo $ANSIBLE_EC2_PREFIX`" "$@"
+    ansible-playbook -i inventories/ec2/ stress.yaml --limit "tag_user_`echo $ANSIBLE_EC2_PREFIX`" -e "@inventories/ec2/group_vars/all.yaml" -e "iteration=$i" -e "setup_name=`echo $ANSIBLE_EC2_PREFIX`" "$@"
 done
 ansible-playbook -i inventories/ec2/ collect-stress.yaml "$@"

--- a/group_vars/all
+++ b/group_vars/all
@@ -37,3 +37,6 @@ use_db_ami: true
 use_reflector: true
 
 dc_suffix: _test
+
+# path to public key
+public_key_path: "~/.ssh/id_rsa.pub"

--- a/inventories/ec2/group_vars/all.yaml
+++ b/inventories/ec2/group_vars/all.yaml
@@ -7,7 +7,6 @@ regions:
     scylla_ami: ami-7251bb12  # Scylla 1.0
     ubuntu_image: ami-3f68640f # ubuntu 14.04
     fedora_ami: ami-05f4ed35 # fedora 22
-    key_name: tzach-oregon
     security_group: cassandra-security-group # make sure security group is corralte to vpc
     vpc_subnet_id: subnet-5207ee37
   us-east-1:
@@ -16,7 +15,6 @@ regions:
     scylla_ami: ami-5152583b  # Scylla 1.0
     ubuntu_image: ami-d05e75b8 # ubuntu 14.04
     fedora_ami: ami-a51564c0 # fedora 22
-    key_name: tzach-virginia
     security_group: cassandra-security-group # make sure security group is corralte to vpc
     vpc_subnet_id: subnet-ec4a72c4
   us-west-1:
@@ -24,7 +22,6 @@ regions:
     cassandra_ami: ami-3cf7c979 # DataStax Auto-Clustering AMI 2.5.1-hvm
     scylla_ami: ami-3ce4995c # Scylla 1.0
     fedora_ami: ami-c9e21e8d # fedora 22
-    key_name: tzach-california
     security_group: cassandra-security-group # make sure security group is corralte to vpc
     vpc_subnet_id: subnet-10a04c75
 
@@ -44,3 +41,5 @@ loader_login: fedora
 instance_type: c3.xlarge
 
 setup_name: "{{ansible_env.ANSIBLE_EC2_PREFIX}}"
+
+

--- a/provision-db.yaml
+++ b/provision-db.yaml
@@ -30,7 +30,7 @@
       local_action:
         module: ec2
         region: "{{item.value.region_name}}"
-        keypair: "{{item.value.key_name}}"
+        keypair: "{{setup_name}}-test-and-deploy-key"
         group: "{{item.value.security_group}}"
         vpc_subnet_id: "{{item.value.vpc_subnet_id}}"
         assign_public_ip: yes

--- a/provision-loadgen.yaml
+++ b/provision-loadgen.yaml
@@ -9,7 +9,7 @@
       local_action:
         module: ec2
         region: "{{item.value.region_name}}"
-        keypair: "{{item.value.key_name}}"
+        keypair: "{{setup_name}}-test-and-deploy-key"
         group: "{{item.value.security_group}}"
         vpc_subnet_id: "{{item.value.vpc_subnet_id}}"
         assign_public_ip: yes

--- a/setup-ec2-cassandra.yaml
+++ b/setup-ec2-cassandra.yaml
@@ -1,3 +1,4 @@
 ---
+- include: create-keys.yaml
 - include: provision-db.yaml db=cassandra db_version=community
 - include: prepare-cassandra.yaml

--- a/setup-ec2-loadgen.yaml
+++ b/setup-ec2-loadgen.yaml
@@ -1,3 +1,4 @@
 ---
+- include: create-keys.yaml
 - include: provision-loadgen.yaml
 - include: prepare-loadgen.yaml

--- a/setup-ec2-scylla.yaml
+++ b/setup-ec2-scylla.yaml
@@ -1,3 +1,4 @@
 ---
+- include: create-keys.yaml
 - include: provision-db.yaml db=scylla db_version=community
 - include: prepare-scylla.yaml


### PR DESCRIPTION
Having EC2 key names as part of the repo is problematic,  as each user need to update it.
With this PR, the user use his own key.
The new playbook,  create-keys.yaml, upload the key to all relevant regions, if not already there.
