### PR TITLE
install and run collectd_exporter, a prometheus client

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Scylla servers launch from Scylla AMI, base on Fedora 22 (login fedora)
   * ```-e "instance_type=c3.8xlarge"``` - type of EC2 instance
   * ```-e "ec2_multiregion=true"```- a multi region EC2 deployment
   * ```-e "collectd_server=your-collectd-server-ip"``` - collectd server to collect metric. See [scylla-monitoring](https://github.com/scylladb/scylla-monitoring) for an example monitoring server
+  * ```-e "prometheus_client=true"``` - install and run a **Prometheus** client, [collectd_exporter](https://github.com/prometheus/collectd_exporter) on each server, exposing a metrics in port 9103
 
 Server are created with EC2 name *DB*, and tag "server=Scylla"
 

--- a/prepare-scylla.yaml
+++ b/prepare-scylla.yaml
@@ -2,6 +2,7 @@
   hosts: NewDB
   user: "{{scylla_login}}"
   tasks:
+    - debug: msg="prometheus_client {{prometheus_client}}"
     - name: wait for scylla service to complete its init procedures
       wait_for: host={{ansible_all_ipv4_addresses[0]}} port=9042 timeout=600
 
@@ -11,6 +12,7 @@
   roles:
     - { role: scylla-config, sudo: yes, when: ec2_multiregion|bool or add_node|bool or not use_db_ami|bool}
     - { role: scylla-collectd-client, sudo: yes, when: collectd_server is defined }
+    - { role: prometheus-client, sudo: yes, when: prometheus_client|bool }
 
 - name: Run scylla nodes
   hosts: NewDB

--- a/prepare-scylla.yaml
+++ b/prepare-scylla.yaml
@@ -2,7 +2,6 @@
   hosts: NewDB
   user: "{{scylla_login}}"
   tasks:
-    - debug: msg="prometheus_client {{prometheus_client}}"
     - name: wait for scylla service to complete its init procedures
       wait_for: host={{ansible_all_ipv4_addresses[0]}} port=9042 timeout=600
 
@@ -12,7 +11,7 @@
   roles:
     - { role: scylla-config, sudo: yes, when: ec2_multiregion|bool or add_node|bool or not use_db_ami|bool}
     - { role: scylla-collectd-client, sudo: yes, when: collectd_server is defined }
-    - { role: prometheus-client, sudo: yes, when: prometheus_client|bool }
+    - { role: prometheus-client, sudo: yes, when: prometheus_client is defined }
 
 - name: Run scylla nodes
   hosts: NewDB

--- a/roles/prometheus-client/handlers/main.yaml
+++ b/roles/prometheus-client/handlers/main.yaml
@@ -1,0 +1,2 @@
+- name: restart collectd
+  action: service name=collectd enabled=yes pattern=collectd state=restarted

--- a/roles/prometheus-client/handlers/main.yaml
+++ b/roles/prometheus-client/handlers/main.yaml
@@ -1,2 +1,0 @@
-- name: restart collectd
-  action: service name=collectd enabled=yes pattern=collectd state=restarted

--- a/roles/prometheus-client/tasks/main.yaml
+++ b/roles/prometheus-client/tasks/main.yaml
@@ -1,0 +1,17 @@
+---
+- yum: name={{ item }} state=present update_cache=yes
+  with_items:
+    - git
+
+- action: template src=scylla.conf dest=/etc/collectd.d/scylla.conf owner=root group=root
+  notify:
+    - restart collectd
+
+- git: repo=https://github.com/prometheus/collectd_exporter dest=/home/centos/collectd_exporter
+
+- name: Running make for collectd_exporter
+  command: make chdir='/home/centos/collectd_exporter'
+
+- command: /home/centos/collectd_exporter/collectd_exporter -collectd.listen-address=":65534"
+  async: 604800
+  poll: 0

--- a/roles/prometheus-client/tasks/main.yaml
+++ b/roles/prometheus-client/tasks/main.yaml
@@ -3,10 +3,6 @@
   with_items:
     - git
 
-- action: template src=scylla.conf dest=/etc/collectd.d/scylla.conf owner=root group=root
-  notify:
-    - restart collectd
-
 - git: repo=https://github.com/prometheus/collectd_exporter dest=/home/centos/collectd_exporter
 
 - name: Running make for collectd_exporter
@@ -15,3 +11,9 @@
 - command: /home/centos/collectd_exporter/collectd_exporter -collectd.listen-address=":65534"
   async: 604800
   poll: 0
+
+- name: upload scylla collectd config
+  template: src=scylla.conf dest=/etc/collectd.d/scylla.conf owner=root group=root
+
+- name: restart collectd service
+  service: name=collectd state=restarted

--- a/roles/prometheus-client/templates/scylla.conf
+++ b/roles/prometheus-client/templates/scylla.conf
@@ -1,6 +1,7 @@
 LoadPlugin network
 LoadPlugin disk
 LoadPlugin interface
+LoadPlugin unixsock
 <Plugin network>
         Listen "127.0.0.1" "25826"
         Server "127.0.0.1" "65534"
@@ -13,4 +14,8 @@ LoadPlugin interface
 <Plugin interface>
         Interface "(eth|int)0"
         IgnoreSelected false
+</Plugin>
+<Plugin unixsock>
+	SocketFile "/var/run/collectd-unixsock"
+	SocketPerms "0666"
 </Plugin>

--- a/roles/prometheus-client/templates/scylla.conf
+++ b/roles/prometheus-client/templates/scylla.conf
@@ -1,0 +1,16 @@
+LoadPlugin network
+LoadPlugin disk
+LoadPlugin interface
+<Plugin network>
+        Listen "127.0.0.1" "25826"
+        Server "127.0.0.1" "65534"
+        Forward true
+</Plugin>
+<Plugin disk>
+        Disk "/^([hs]d[a-f]|md)[0-9]?$/"
+        IgnoreSelected false
+</Plugin>
+<Plugin interface>
+        Interface "(eth|int)0"
+        IgnoreSelected false
+</Plugin>

--- a/roles/prometheus-client/templates/scylla.conf
+++ b/roles/prometheus-client/templates/scylla.conf
@@ -8,12 +8,8 @@ LoadPlugin unixsock
         Forward true
 </Plugin>
 <Plugin disk>
-        Disk "/^([hs]d[a-f]|md)[0-9]?$/"
-        IgnoreSelected false
 </Plugin>
 <Plugin interface>
-        Interface "(eth|int)0"
-        IgnoreSelected false
 </Plugin>
 <Plugin unixsock>
 	SocketFile "/var/run/collectd-unixsock"


### PR DESCRIPTION
This PR add a new role for collectd_exporter, a prometheus compatible client.
To use it, run set up with `prometheus_client=true`
Example:

```
./ec2-setup-scylla.sh -e "cluster_nodes=3" -e "prometheus_client=true"
```
