### PR TITLE
Allow each different population range per loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ notation. Examples below:
 * ```-e "threads=200"```
 * ```-e "profile_dir=/tmp/cassandra-stress-profiles/" -e "profile_file=cust_a/users/users1.yaml" -e "command_options=ops\\(insert=1\\)"```
 * ```-e "clean_data=true"``` - clean all data from DB servers and restart them before starting the stress
+* ```-e "seq_populate=100"``` - populate different range per loader, using `-pop seq=1..100`,  `-pop seq=101..200` etc
 
 Make sure **load name is unique**  so the new results will not
 override an old run in the same day.

--- a/roles/loader/tasks/main.yaml
+++ b/roles/loader/tasks/main.yaml
@@ -6,3 +6,21 @@
 - name: Install Scylla tools
   dnf: name=scylla-tools
   sudo: yes
+
+- name: Gather facts
+  action: ec2_facts
+
+- set_fact:
+    id: "{{ansible_ec2_instance_id}}"
+    region: "{{ ansible_ec2_placement_availability_zone | regex_replace('(.*[1-9])(.)', '\\\\1' ) }}"
+  when: ansible_ec2_instance_id is defined
+
+- set_fact: index="{{ansible_ec2_ami_launch_index}}"
+  when: ansible_ec2_ami_launch_index is defined
+
+- name: Tag instance index
+  local_action: ec2_tag resource={{id}} state=present region={{region}}
+  when: ansible_ec2_ami_launch_index is defined
+  args:
+    tags:
+      index: "{{index}}"

--- a/stress.yaml
+++ b/stress.yaml
@@ -9,6 +9,16 @@
     iteration: 0 # overload me
     server: "Scylla"
   tasks:
+    - set_fact: index={{ec2_tag_index}}
+    - set_fact: range_start={{1 + (seq_populate|int) * (index|int) }}
+      when: seq_populate is defined
+    - set_fact: range_end={{(seq_populate|int) * (1 + (index|int)) }}
+      when: seq_populate is defined
+    - set_fact: range="{{range_start}}..{{range_end}}"
+      when: seq_populate is defined
+    - debug: msg="client key range {{range}}"
+      when: seq_populate is defined
+
     - set_fact: loader_ip="{{ansible_eth0.ipv4.address}}"
 
     - name: Gather facts
@@ -51,11 +61,17 @@
       when: profile_file is undefined
       run_once: true
 
-    - shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress {{command}} no-warmup {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
-      when: profile_file is undefined
+    - name: run stress for seq populate
+      shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress write no-warmup {{command_options}} -pop seq={{range}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
+      when: profile_file is undefined and seq_populate is defined
+
+    - name: run stress
+      shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress {{command}} no-warmup {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
+      when: profile_file is undefined and seq_populate is undefined
       ignore_errors: True
 
-    - shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress user profile={{profile_file}} no-warmup {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
+    - name: run stress with profile
+      shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress user profile={{profile_file}} no-warmup {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
       when: profile_file is defined
       ignore_errors: True
 


### PR DESCRIPTION
Fix #95 by adding a new option to the stress command:
`-e "seq_populate=100"` - populate different range per loader, using `-pop seq=1..100`,  `-pop seq=101..200` etc
