### PR TITLE
Add processes plugin to collectd config

### DIFF
--- a/roles/prometheus-client/templates/scylla.conf
+++ b/roles/prometheus-client/templates/scylla.conf
@@ -3,6 +3,7 @@ LoadPlugin disk
 LoadPlugin interface
 LoadPlugin unixsock
 LoadPlugin df
+LoadPlugin processes
 <Plugin network>
         Listen "127.0.0.1" "25826"
         Server "127.0.0.1" "65534"
@@ -19,4 +20,7 @@ LoadPlugin df
 <Plugin unixsock>
 	SocketFile "/var/run/collectd-unixsock"
 	SocketPerms "0666"
+</Plugin>
+<Plugin processes>
+    Process "scylla"
 </Plugin>


### PR DESCRIPTION
This change exposes scylla process status to external monitoring.
See scylla-grafana-monitoring dashboard "Dead Node" as an example[1]

![image](https://cloud.githubusercontent.com/assets/170200/16844808/38614c62-49ef-11e6-8e25-eff2afece60a.png)

[1] https://github.com/scylladb/scylla-grafana-monitoring/pull/34
