### PR TITLE
remove scylla-jmx restart

### DIFF
--- a/roles/scylla-config/tasks/start.yaml
+++ b/roles/scylla-config/tasks/start.yaml
@@ -3,14 +3,8 @@
   action: service name=scylla-server enabled=yes state=restarted
   sudo: yes
 
-## scylla-jmx goes down if scylla-server goes down, but not the other way around.
-## See issue https://github.com/scylladb/scylla/issues/504
 - name: wait for scylla service to complete its init procedures
   wait_for: host={{ansible_all_ipv4_addresses[0]}} port=9042 timeout=600
-
-- name: start scylla-jmx service
-  action: service name=scylla-jmx enabled=yes state=restarted
-  sudo: yes
 
 - name: Gather facts
   action: ec2_facts


### PR DESCRIPTION
Since https://github.com/scylladb/scylla/issues/504 is fixed, there is no need to restart scylla-jmx after starting scylla-server