### PR TITLE
YCSB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,15 @@ Loaders are launch from Scylla AMI, base on Fedora 22 (login fedora), including 
   **options**
   * ```-e "load_nodes=2"``` - number of loaders **per region** (default 2)
   * ```-e "instance_type=m3.large"``` - type of EC2 instance
+  * ```-e "ycsb=true"``` - YCSB loader
+
 
 #### Add nodes to existing cluster
 ```
 ./ec2-add-node-to-cluster.sh -e "server=Cassandra"
 ```
   **options**
-  * ```-e "server=[Cassandra|Scylla]"``` 
+  * ```-e "server=[Cassandra|Scylla]"```
   * ```-e "stopped=true"``` - start server is stopped state
   * ```-e "instance_type=m3.large"``` - type of EC2 instance
   * ```-e "cluster_nodes=2"``` - number of nodes to add (default is 2)
@@ -151,7 +153,7 @@ Loaders are launch from Scylla AMI, base on Fedora 22 (login fedora), including 
 ./ec2-start-server.sh
 ```
 
-### Run Load
+### Run Cassandra Stress Load
 
 ```
 ./ec2-stress.sh <iterations> -e "load_name=late_night" -e "server=Scylla" <more options>
@@ -185,6 +187,22 @@ Make sure **load name is unique**  so the new results will not
 override an old run in the same day.
 
 Load name can not not include *-* (dash)
+
+### Run YCSB Load
+
+(make to sure to create YCSB loaders in advance)
+
+```
+./ec2-stress-ycsb.sh <iterations> -e "load_name=late_night" -e "server=Scylla" <more options>
+```
+
+To override each of the parameter, use the ``-e "param=value"
+notation. Examples below:
+* ```-e "workload=workloada"``` Choose YCSB workload
+* ```-e "ycsb-prepare=false"``` do *not* run YCSB prepare phase (defualt is true)
+* ```-e "recordcount=30000"``` YCSB prepare recoreds count
+* ```-e "prepere_options='-p recordcount=100000'"```
+* ```-e "run_options='-p operationcount=1000000 -p cassandra.writeconsistencylevel=QUORUM -p cassandcra.readconsistencylevel=QUORUM'"```
 
 ### Results
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ notation. Examples below:
 * ```-e "ycsb-prepare=false"``` do *not* run YCSB prepare phase (defualt is true)
 * ```-e "recordcount=30000"``` YCSB prepare recoreds count
 * ```-e "prepere_options='-p recordcount=100000'"```
+* ```-e "seq_populate=100"``` - populate different range per loader, using `-pop seq=1..100`,  `-pop seq=101..200` etc
 * ```-e "run_options='-p operationcount=1000000 -p cassandra.writeconsistencylevel=QUORUM -p cassandcra.readconsistencylevel=QUORUM'"```
 
 ### Results

--- a/ec2-stress-ycsb.sh
+++ b/ec2-stress-ycsb.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+iterations=$1
+shift
+
+for i in `seq 1 $iterations`;
+do
+    echo "iteration $i"
+    ansible-playbook -i inventories/ec2/ stress-ycsb.yaml --limit "tag_user_`echo $ANSIBLE_EC2_PREFIX`" -e "@inventories/ec2/group_vars/all.yaml" -e "iteration=$i" -e "setup_name=`echo $ANSIBLE_EC2_PREFIX`" "$@"
+done
+#ansible-playbook -i inventories/ec2/ collect-stress.yaml "$@"

--- a/group_vars/all
+++ b/group_vars/all
@@ -23,6 +23,8 @@ threads: 250
 clean_data: false
 profile_dir: /tmp/cassandra-stress-profiles/
 
+ycsb: false
+
 #others
 s3_buckt: cassandra.test
 upload_to_s3: false

--- a/group_vars/all
+++ b/group_vars/all
@@ -23,6 +23,7 @@ threads: 250
 clean_data: false
 profile_dir: /tmp/cassandra-stress-profiles/
 
+# YCSB
 ycsb: false
 
 #others

--- a/group_vars/all
+++ b/group_vars/all
@@ -8,20 +8,12 @@ cluster_name: CassandraCluster
 
 cassandra_ver: 2.1.8
 
-# load
-load_name: run
-command: write
-command_options:
-output_format: cassandra-stress.{{command}}.{{load_name}}.{{ansible_date_time.date}}
-output_file: "{{output_format}}"
+## load options
+clean_data: false
+sleep_between_runs: 60
 remote_path: /home/{{loader_login}}/
 home_path: /tmp/cassandra-results/
-stress_options:
-populate: 1000000
-sleep_between_runs: 60
-threads: 250
-clean_data: false
-profile_dir: /tmp/cassandra-stress-profiles/
+load_name: run
 
 # YCSB
 ycsb: false

--- a/group_vars/cassandra_stress_vars.yaml
+++ b/group_vars/cassandra_stress_vars.yaml
@@ -1,0 +1,11 @@
+# load
+command: write
+command_options:
+output_format: cassandra-stress.{{command}}.{{load_name}}.{{ansible_date_time.date}}
+output_file: "{{output_format}}"
+stress_options:
+populate: 1000000
+
+threads: 250
+
+profile_dir: /tmp/cassandra-stress-profiles/

--- a/group_vars/ycsb_vars.yaml
+++ b/group_vars/ycsb_vars.yaml
@@ -1,0 +1,15 @@
+---
+prepare: true
+workload: workloada
+command_options:
+output_format: ycsb.{{workload}}.{{load_name}}.{{ansible_date_time.date}}
+output_file: "{{output_format}}"
+remote_path: /home/{{loader_login}}/
+home_path: /tmp/cassandra-results/
+stress_options:
+sleep_between_runs: 60
+threads: 100
+clean_data: false
+profile_dir: /tmp/cassandra-stress-profiles/
+prepere_options:
+run_options:

--- a/inventories/ec2/group_vars/all.yaml
+++ b/inventories/ec2/group_vars/all.yaml
@@ -12,7 +12,7 @@ regions:
   us-east-1:
     region_name: us-east-1
     cassandra_ami: ami-ada2b6c4 # DataStax Auto-Clustering AMI 2.5.1-hvm
-    scylla_ami: ami-38c2f22f  # Scylla 1.5 rc1
+    scylla_ami: ami-79d3f06e  # Scylla 1.4.1
     ubuntu_image: ami-d05e75b8 # ubuntu 14.04
     loader_ami: ami-6d1c2007 # centos 7.2
     security_group: cassandra-security-group # make sure security group is corralte to vpc
@@ -26,7 +26,7 @@ regions:
     vpc_subnet_id: subnet-10a04c75
 
 # subset of the region use when ec2_multiregion is false
-region_to_use: "us-east-1"
+region_to_use: "us-west-2"
 region_to_use_data:
   region_to_use: "{{regions[region_to_use]}}"
 

--- a/inventories/ec2/group_vars/all.yaml
+++ b/inventories/ec2/group_vars/all.yaml
@@ -12,7 +12,7 @@ regions:
   us-east-1:
     region_name: us-east-1
     cassandra_ami: ami-ada2b6c4 # DataStax Auto-Clustering AMI 2.5.1-hvm
-    scylla_ami: ami-79d3f06e  # Scylla 1.4.1
+    scylla_ami: ami-38c2f22f  # Scylla 1.5 rc1
     ubuntu_image: ami-d05e75b8 # ubuntu 14.04
     loader_ami: ami-6d1c2007 # centos 7.2
     security_group: cassandra-security-group # make sure security group is corralte to vpc
@@ -26,7 +26,7 @@ regions:
     vpc_subnet_id: subnet-10a04c75
 
 # subset of the region use when ec2_multiregion is false
-region_to_use: "us-west-2"
+region_to_use: "us-east-1"
 region_to_use_data:
   region_to_use: "{{regions[region_to_use]}}"
 

--- a/prepare-loadgen.yaml
+++ b/prepare-loadgen.yaml
@@ -2,4 +2,5 @@
   hosts: CassandraLoadgen
   user: "{{loader_login}}"
   roles:
-     - { role: loader }
+     - { role: loader, when: not ycsb | bool }
+     - { role: loader-ycsb, when: ycsb | bool }

--- a/roles/cassandra-ycsb-prepare/tasks/main.yaml
+++ b/roles/cassandra-ycsb-prepare/tasks/main.yaml
@@ -1,0 +1,10 @@
+---
+
+- name: upload cql file
+  action: template src=create_table.cql dest=~/create_table.cql
+  run_once: true
+
+- name: run CQL file
+  shell: cqlsh < ~/create_table.cql
+  run_once: true
+

--- a/roles/cassandra-ycsb-prepare/templates/create_table.cql
+++ b/roles/cassandra-ycsb-prepare/templates/create_table.cql
@@ -1,0 +1,13 @@
+create keyspace ycsb WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': {{ycsb_replication_factor}} };
+create table ycsb.usertable (
+    y_id varchar primary key,
+    field0 varchar,
+    field1 varchar,
+    field2 varchar,
+    field3 varchar,
+    field4 varchar,
+    field5 varchar,
+    field6 varchar,
+    field7 varchar,
+    field8 varchar,
+    field9 varchar);

--- a/roles/cassandra-ycsb-prepare/vars/main.yaml
+++ b/roles/cassandra-ycsb-prepare/vars/main.yaml
@@ -1,0 +1,1 @@
+ycsb_replication_factor: 1

--- a/roles/java-rpm/tasks/main.yaml
+++ b/roles/java-rpm/tasks/main.yaml
@@ -1,0 +1,27 @@
+---
+
+- name: Install prerequisites
+  yum: name={{ item }}
+  sudo: yes
+  with_items:
+     - wget
+
+- name: Download Java RPM
+  sudo: yes
+  command: "wget -q -O {{oracle_java_path}} --no-check-certificate --no-cookies --header 'Cookie: oraclelicense=accept-securebackup-cookie' {{oracle_java_rpm_url}} creates={{ oracle_java_path }}"
+
+- name: install RPM
+  sudo: yes
+  action: "{{ ansible_pkg_mgr }} name={{ oracle_java_path }} state=present"
+
+- name: set Java version as default
+  alternatives:
+    name="{{ item.exe }}"
+    link="/usr/bin/{{ item.exe }}"
+    path="{{ item.path }}/{{ item.exe }}"
+  with_items:
+    - { path: "{{ oracle_java_home }}/jre/bin", exe: 'java' }
+    - { path: "{{ oracle_java_home }}/jre/bin", exe: 'keytool' }
+    - { path: "{{ oracle_java_home }}/bin", exe: 'javac' }
+    - { path: "{{ oracle_java_home }}/bin", exe: 'javadoc' }
+  sudo: yes

--- a/roles/java-rpm/vars/main.yaml
+++ b/roles/java-rpm/vars/main.yaml
@@ -1,0 +1,12 @@
+---
+## java_file: jdk-8u111-linux-x64.tar.gz
+
+oracle_java_version: 8
+oracle_java_version_update: 111
+oracle_java_version_build: 14
+
+oracle_java_dir_source: "/usr/local/src"
+oracle_java_home: "/usr/java/jdk1.{{ oracle_java_version }}.0_{{ oracle_java_version_update }}"
+oracle_java_rpm_filename: "jdk-{{ oracle_java_version }}u{{ oracle_java_version_update }}-linux-x64.rpm"
+oracle_java_rpm_url: "http://download.oracle.com/otn-pub/java/jdk/{{ oracle_java_version }}u{{ oracle_java_version_update }}-b{{ oracle_java_version_build }}/{{ oracle_java_rpm_filename }}"
+oracle_java_path: "{{ oracle_java_dir_source }}/{{ oracle_java_rpm_filename }}"

--- a/roles/loader-ycsb/meta/main.yaml
+++ b/roles/loader-ycsb/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: java-rpm }

--- a/roles/loader-ycsb/tasks/main.yaml
+++ b/roles/loader-ycsb/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+- debug: msg="installing YCSB"
+
+- name: download YCSB source code
+  get_url: url={{ download_path }}
+           dest={{ ycsb_path }}
+  args:
+    validate_certs: False
+
+- name: unarchive YCSB
+  unarchive: src={{ ycsb_path }} dest={{ destination }}/ copy=no
+
+- name: rename ycsb.x to ycsb
+  command: mv {{ destination }}/ycsb-{{version}} {{ destination }}/ycsb

--- a/roles/loader-ycsb/vars/main.yaml
+++ b/roles/loader-ycsb/vars/main.yaml
@@ -1,0 +1,5 @@
+version: '0.11.0'
+download_path: 'https://github.com/brianfrankcooper/YCSB/releases/download/{{version}}/ycsb-{{version}}.tar.gz'
+destination: '/home/centos'
+ycsb_path: '{{ destination }}/ycsb-{{ version }}.tar.gz'
+

--- a/roles/loader-ycsb/vars/main.yaml
+++ b/roles/loader-ycsb/vars/main.yaml
@@ -1,5 +1,5 @@
 version: '0.11.0'
 download_path: 'https://github.com/brianfrankcooper/YCSB/releases/download/{{version}}/ycsb-{{version}}.tar.gz'
-destination: '/home/centos'
+destination: '~'
 ycsb_path: '{{ destination }}/ycsb-{{ version }}.tar.gz'
 

--- a/stress-ycsb.yaml
+++ b/stress-ycsb.yaml
@@ -22,6 +22,8 @@
 
   tasks:
 
+    - include_vars: group_vars/ycsb_vars.yaml
+
     - name: Gather facts
       action: ec2_facts
 
@@ -70,11 +72,12 @@
     - set_fact: log_file="{{remote_path}}{{output_file}}.{{ec2_region}}.{{loader_ip}}"
 
     - name: YCSB prepere
-      shell: ~/ycsb/bin/ycsb load cassandra2-cql -P ~/ycsb/workloads/workloada -p hosts={{ip_list}}
+      shell: ~/ycsb/bin/ycsb load cassandra2-cql -P ~/ycsb/workloads/{{workload}} -p hosts={{ip_list}} {{prepere_options}}
+      when: prepare
       run_once: true
 
     - name: YCSB run
-      shell: ~/ycsb/bin/ycsb run cassandra2-cql -P ~/ycsb/workloads/workloada -p hosts={{ip_list}} > {{log_file}}.{{iteration}}.data
+      shell: ~/ycsb/bin/ycsb run cassandra2-cql -P ~/ycsb/workloads/{{workload}} -s -threads {{threads}} -p hosts={{ip_list}} {{run_options}} > {{log_file}}.{{iteration}}.data
 
     - fetch: src={{log_file}}.{{iteration}}.data dest={{home_path}}{{output_file}}.{{ec2_region}}.{{loader_ip}}.{{iteration}}.data flat=yes
       ignore_errors: True

--- a/stress-ycsb.yaml
+++ b/stress-ycsb.yaml
@@ -1,0 +1,83 @@
+---
+- include: clean_data.yaml
+
+- name: YCSB Prepare
+  hosts: "Scylla:!Stopped"
+  user: "{{scylla_login}}"
+  roles:
+    - { role: cassandra-ycsb-prepare }
+
+- name: YCSB Prepare
+  hosts: "Cassandra:!Stopped"
+  user: "{{cassandra_login}}"
+  roles:
+    - { role: cassandra-ycsb-prepare }
+
+- name: Run stress
+  hosts: "CassandraLoadgen"
+  user: "{{loader_login}}"
+  vars:
+    iteration: 0 # overload me
+    server: "Scylla"
+
+  tasks:
+
+    - name: Gather facts
+      action: ec2_facts
+
+    - set_fact: index={{ansible_ec2_ami_launch_index}}
+    - set_fact: range_start={{1 + (seq_populate|int) * (index|int) }}
+      when: seq_populate is defined
+    - set_fact: range_end={{(seq_populate|int) * (1 + (index|int)) }}
+      when: seq_populate is defined
+    - set_fact: range="{{range_start}}..{{range_end}}"
+      when: seq_populate is defined
+    - debug: msg="client key range {{range}}"
+      when: seq_populate is defined
+
+    - set_fact: loader_ip="{{ansible_eth0.ipv4.address}}"
+
+
+    - set_fact:
+        user_group: "tag_user_{{setup_name}}"
+
+    - debug: msg="{{ hostvars[item].ec2_private_ip_address }}"
+      with_items: groups.DB | intersect (groups[ec2_region]) | intersect (groups[user_group]) | intersect (groups[server]) | difference(groups.Stopped)
+      register: output
+
+    - set_fact: ip_list={{ output.results|map(attribute='msg') | join(',') }}
+
+    - debug: msg="ip_list is {{ip_list}}"
+
+    - set_fact: taskset="taskset -c {{load_cpus}}"
+      when: load_cpus is defined
+
+    - set_fact: taskset=""
+      when: load_cpus is not defined
+
+    - debug: msg="setting network IRQ affinity to CPU0"
+      when: load_cpus is defined
+
+    - shell: for irq in `cat  /proc/interrupts | grep eth0 | cut -d":" -f1`; do echo 1 > /proc/irq/$irq/smp_affinity; done
+      when: load_cpus is defined
+      sudo: yes
+
+    - name: kill java, if already running
+      shell: pkill java
+      sudo: yes
+      ignore_errors: True
+
+    - set_fact: log_file="{{remote_path}}{{output_file}}.{{ec2_region}}.{{loader_ip}}"
+
+    - name: YCSB prepere
+      shell: ~/ycsb/bin/ycsb load cassandra2-cql -P ~/ycsb/workloads/workloada -p hosts={{ip_list}}
+      run_once: true
+
+    - name: YCSB run
+      shell: ~/ycsb/bin/ycsb run cassandra2-cql -P ~/ycsb/workloads/workloada -p hosts={{ip_list}} > {{log_file}}.{{iteration}}.data
+
+    - fetch: src={{log_file}}.{{iteration}}.data dest={{home_path}}{{output_file}}.{{ec2_region}}.{{loader_ip}}.{{iteration}}.data flat=yes
+      ignore_errors: True
+
+    - local_action: s3 bucket={{s3_buckt}} object={{output_file}}/{{output_file}}.{{ec2_region}}.{{loader_ip}}.{{iteration}} src={{home_path}}{{output_file}}.{{loader_ip}}.{{iteration}} mode=put
+      when: upload_to_s3

--- a/stress-ycsb.yaml
+++ b/stress-ycsb.yaml
@@ -78,6 +78,11 @@
 
     - name: YCSB run
       shell: ~/ycsb/bin/ycsb run cassandra2-cql -P ~/ycsb/workloads/{{workload}} -s -threads {{threads}} -p hosts={{ip_list}} {{run_options}} > {{log_file}}.{{iteration}}.data
+      when: seq_populate is undefined
+
+    - name: YCSB run
+      shell: ~/ycsb/bin/ycsb run cassandra2-cql -P ~/ycsb/workloads/{{workload}} -s -threads {{threads}} -p hosts={{ip_list}} -p insertstart={{range_start}} -p insertcount={{seq_populate}} {{run_options}} > {{log_file}}.{{iteration}}.data
+      when: seq_populate is defined
 
     - fetch: src={{log_file}}.{{iteration}}.data dest={{home_path}}{{output_file}}.{{ec2_region}}.{{loader_ip}}.{{iteration}}.data flat=yes
       ignore_errors: True

--- a/stress.yaml
+++ b/stress.yaml
@@ -2,6 +2,7 @@
 - include: clean_data.yaml
 - include: stress_profile.yaml
 
+
 - name: Run stress
   hosts: "CassandraLoadgen"
   user: "{{loader_login}}"
@@ -9,6 +10,8 @@
     iteration: 0 # overload me
     server: "Scylla"
   tasks:
+    - include_vars: group_vars/cassandra_stress_vars.yaml
+
     - name: Gather facts
       action: ec2_facts
 


### PR DESCRIPTION
This PR add YCSB support to the project.
To use:
- create loader with ycsb tags: ``` ./ec2-setup-loadgen.sh -e "load_nodes=2" -e "instance_type=c3.xlarge" -e "ycsb=true" ```
- run YCSB load: ```./ec2-stress-ycsb.sh 1 -e "load_name=scylla.v14" -e "server=Scylla" -e "prepere_options='-p recordcount=100000'" -e "run_options='-p operationcount=1000 -p cassandra.writeconsistencylevel=QUORUM -p cassandcra.readconsistencylevel=QUORUM -p operationcount=100'"```

YCSB test, like cassandra-stress, respect the `seq_populate` option to run different range from each loader