### PR TITLE
add a local fork parameter

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,7 @@
+# config file for ansible -- http://ansible.com/
+# Override global Ansible parameters in /etc/ansible/ansible.cfg
+# ==============================================
+
+[defaults]
+
+forks          = 100


### PR DESCRIPTION
This PR add a local ansible.cfg, which override the global Ansible parameters.
In particular it solve #117 in a transparent way
