### PR TITLE
specify rate instead of threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ notation. Examples below:
 * ```-e "stress_options='-errors ignore'"```
 * ```-e "command_options='cl=LOCAL_ONE -mode native cql3'"```
 * ```-e "command_options=duration=60m"```
-* ```-e "threads=200"```
+* ```-e "rate='threads=200'"```
 * ```-e "profile_dir=/tmp/cassandra-stress-profiles/" -e "profile_file=cust_a/users/users1.yaml" -e "command_options=ops\\(insert=1\\)"```
 * ```-e "clean_data=true"``` - clean all data from DB servers and restart them before starting the stress
 * ```-e "seq_populate=100"``` - populate different range per loader, using `-pop seq=1..100`,  `-pop seq=101..200` etc

--- a/group_vars/cassandra_stress_vars.yaml
+++ b/group_vars/cassandra_stress_vars.yaml
@@ -6,6 +6,6 @@ output_file: "{{output_format}}"
 stress_options:
 populate: 1000000
 
-threads: 250
+rate: "threads=250"
 
 profile_dir: /tmp/cassandra-stress-profiles/

--- a/stress.yaml
+++ b/stress.yaml
@@ -65,16 +65,16 @@
       run_once: true
 
     - name: run stress for seq populate
-      shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress write no-warmup {{command_options}} -pop seq={{range}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
+      shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress write no-warmup {{command_options}} -pop seq={{range}} -node {{ip_list}} -rate {{rate}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
       when: profile_file is undefined and seq_populate is defined
 
     - name: run stress
-      shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress {{command}} no-warmup {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
+      shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress {{command}} no-warmup {{command_options}} -node {{ip_list}} -rate {{rate}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
       when: profile_file is undefined and seq_populate is undefined
       ignore_errors: True
 
     - name: run stress with profile
-      shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress user profile={{profile_file}} no-warmup {{command_options}} -node {{ip_list}} -rate threads={{threads}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
+      shell: sleep {{sleep_between_runs}}; {{taskset}} cassandra-stress user profile={{profile_file}} no-warmup {{command_options}} -node {{ip_list}} -rate {{rate}} -log file={{log_file}}.{{iteration}}.data {{stress_options}}
       when: profile_file is defined
       ignore_errors: True
 


### PR DESCRIPTION
Currently we specify a threads variable, and let the user specify the
number of threads to run. However, in cassandra-stress the threads
parameters is part of the "rate" option, that has other options as well.

One way to handle that would be to keep the threads variable and add a
second optional variable with extraneous options. However, in line with
other tunables that we already have (like command_options and
stress_options), I opted for just exposing the whole -rate as a unit.

Signed-off-by: Glauber Costa <glauber@scylladb.com>